### PR TITLE
fix(screenshot): copy thumbnails into shared assets folder

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -153,7 +153,9 @@ async function buildPublicFolder (options) {
   const sharedDest = path.join(publicDir, options.paths.sharedAssets);
   try {
     await fsPromises.cp(sharedSrc, sharedDest, { recursive: true });
-  } catch (e) {}
+  } catch (e) {
+    utils.log.warn(e);
+  }
 
   // Root index.html: redirect to first KM, or a configured override URL
   const previewRedirectURL = options.paths.previewURLDefault || (firstKmSlug ? `./${firstKmSlug}/index.html` : null);

--- a/lib/tasks/screenshot.js
+++ b/lib/tasks/screenshot.js
@@ -74,11 +74,14 @@ async function copyThumbnails (options) {
   }
   utils.log.log(utils.log.chalk.green.bold('     ✔︎ Copying thumbnails to shared assets'));
 
-  const thumbFiles = glob.sync(path.join(options.paths.dist, '**', '*-thumb.jpg'));
+  const thumbFiles = glob.sync(path.join(options.paths.dist, '**', 'thumb.png'));
   const outDir = path.join(options.paths.dist, options.paths.sharedAssets, 'img', 'flyout-menu');
   await fsPromises.mkdir(outDir, { recursive: true });
 
-  await Promise.all(thumbFiles.map((file) => fsPromises.copyFile(file, path.join(outDir, path.basename(file)))));
+  await Promise.all(thumbFiles.map((file) => {
+    const keyMessage = path.basename(path.dirname(file));
+    return fsPromises.copyFile(file, path.join(outDir, `${keyMessage}-thumb.png`));
+  }));
 }
 
 async function handleTempReferences (options) {


### PR DESCRIPTION
copyThumbnails globbed for *-thumb.jpg, but generateThumbnails writes thumb.png (matching deploy.js's exclusion list and the configured default name), so the glob never matched anything and the shared flyout-menu folder was silently left empty. This was masked locally because cleanPreview never wipes the dist/ directory between runs, but was fully exposed on a fresh checkout (e.g. Cloudflare Pages), where no leftover files existed to paper over the mismatch.

Fix the glob to match the real filename and namespace each copied file by its key message so multiple key messages don't collide onto the same destination name. Also stop silently swallowing errors when copying shared assets into public/ so a failed copy is surfaced instead of hidden.